### PR TITLE
Fix grant expiry not auto-resolving

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "kickflip",
       "runtimeExecutable": "uvicorn",
-      "runtimeArgs": ["app.main:app", "--host", "0.0.0.0", "--port", "8123", "--reload"],
+      "runtimeArgs": ["app.main:app", "--host", "0.0.0.0", "--port", "8123", "--reload", "--reload-exclude", "*.db", "--reload-exclude", "*.db-shm", "--reload-exclude", "*.db-wal"],
       "port": 8123
     }
   ]

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.database import init_db
 from app.routers.grants import router as grants_router
-from app.scheduler import scheduler
+from app.scheduler import scheduler, start_expiry_sweep
 from app.tasks import recover_on_startup
 
 logging.basicConfig(
@@ -24,6 +24,7 @@ STATIC_DIR = Path(__file__).parent.parent / "static"
 async def lifespan(app: FastAPI):
     await init_db()
     scheduler.start()
+    start_expiry_sweep()
     await recover_on_startup()
     log.info("Kickflip started")
     yield

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -37,6 +37,20 @@ def schedule_revert(grant_id: int, car_id: str, run_at: datetime) -> None:
     log.info("Revert for grant %d (CAR %s) scheduled at %s", grant_id, car_id, run_at)
 
 
+def start_expiry_sweep() -> None:
+    """Periodic safety-net: revert any active grants whose window has passed."""
+    from app.tasks import recover_on_startup  # same logic — expire & push
+
+    scheduler.add_job(
+        recover_on_startup,
+        "interval",
+        seconds=30,
+        id="expiry-sweep",
+        replace_existing=True,
+    )
+    log.info("Expiry sweep scheduled every 30s")
+
+
 def cancel_revert(grant_id: int) -> None:
     job_id = f"revert-{grant_id}"
     if scheduler.get_job(job_id):


### PR DESCRIPTION
## Problem

Active grants were getting stuck at `00:00` in the UI and never moving to history.

## Root causes

**1. `--reload` watching `grants.db`**
uvicorn's file watcher was picking up writes to `grants.db` (new grants, scheduler job persistence) and restarting the worker process. This killed APScheduler before the `date` trigger job could fire.

**2. No live safety-net for missed reverts**
Once the date-trigger job was lost to a restart, nothing would clean up the expired grant until the next server restart (which triggered `recover_on_startup`).

## Fix

- Added `--reload-exclude *.db` (and `-shm`/`-wal` variants) to the uvicorn launch config so the DB file no longer triggers reloads
- Added a 30-second interval sweep (`start_expiry_sweep`) that runs the same expiry logic as `recover_on_startup` continuously — any grant past its `expires_at` gets reverted within 30s regardless of whether the date-trigger fired

## Test plan

- [ ] Create a grant with `GRANT_DURATION_SECONDS=60`
- [ ] Confirm the grant moves to history within ~30s of the timer hitting 00:00
- [ ] Confirm editing a `.py` file no longer causes the server to restart mid-grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)