### PR TITLE
Add container and k8s support for k3s deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+.env
+*.db
+*.db-shm
+*.db-wal
+.git/
+.claude/
+.github/
+k8s/
+*.md
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+# Create a non-root user
+RUN addgroup --system app && adduser --system --ingroup app app
+
+WORKDIR /app
+
+# Install dependencies first (better layer caching)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app/ ./app/
+COPY static/ ./static/
+
+# Data directory for SQLite — must be backed by a PersistentVolume in k8s
+RUN mkdir -p /data && chown app:app /data
+
+USER app
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.database import init_db
@@ -34,6 +34,11 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Kickflip — Debug Log Enabler", lifespan=lifespan)
 app.include_router(grants_router)
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+@app.get("/health", include_in_schema=False)
+async def health():
+    return JSONResponse({"status": "ok"})
 
 
 @app.get("/", include_in_schema=False)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  kickflip:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - kickflip-data:/data
+    env_file:
+      - .env
+    environment:
+      # Override DB path to use the mounted volume
+      DATABASE_URL: sqlite+aiosqlite:////data/grants.db
+    restart: unless-stopped
+
+volumes:
+  kickflip-data:

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kickflip-config
+  namespace: kickflip
+data:
+  DD_SITE: "datadoghq.com"
+  DD_PIPELINE_IDS: ""          # comma-separated pipeline IDs
+  DD_FILTER_PROCESSOR_ID: "drop-debug"
+  DD_INDEX_NAME: ""            # shared log index name
+  SN_INSTANCE: ""              # yourcompany.service-now.com
+  SN_MIN_SEVERITY: "2"
+  GRANT_DURATION_SECONDS: "600"
+  DATABASE_URL: "sqlite+aiosqlite:////data/grants.db"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,63 @@
+# IMPORTANT: Keep replicas: 1 — SQLite does not support concurrent writers.
+# If you need HA in the future, migrate DATABASE_URL to Postgres first.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kickflip
+  namespace: kickflip
+  labels:
+    app: kickflip
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kickflip
+  strategy:
+    type: Recreate      # Ensures old pod stops before new one starts (SQLite safety)
+  template:
+    metadata:
+      labels:
+        app: kickflip
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        fsGroup: 999
+      containers:
+        - name: kickflip
+          image: kickflip:latest    # Replace with your registry path
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: kickflip-config
+            - secretRef:
+                name: kickflip-secrets
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: kickflip-data

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,21 @@
+# Optional — expose Kickflip outside the cluster via k3s Traefik ingress.
+# Update the host value to match your DNS or local hostname.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kickflip
+  namespace: kickflip
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  rules:
+    - host: kickflip.internal    # replace with your hostname
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kickflip
+                port:
+                  number: 80

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kickflip

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -1,0 +1,14 @@
+# PersistentVolumeClaim for the SQLite database.
+# k3s ships with the local-path provisioner by default, so no StorageClass
+# configuration is needed — it will provision automatically.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kickflip-data
+  namespace: kickflip
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,16 @@
+# Fill in base64-encoded values before applying.
+# Encode a value:  echo -n 'your-value' | base64
+#
+# DO NOT commit real secrets. Use Sealed Secrets, External Secrets, or
+# a secrets manager to inject these in your actual cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kickflip-secrets
+  namespace: kickflip
+type: Opaque
+data:
+  DD_API_KEY: ""         # echo -n 'your-dd-api-key' | base64
+  DD_APP_KEY: ""         # echo -n 'your-dd-app-key' | base64
+  SN_USER: ""            # echo -n 'your-sn-user' | base64
+  SN_PASS: ""            # echo -n 'your-sn-pass' | base64

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kickflip
+  namespace: kickflip
+spec:
+  selector:
+    app: kickflip
+  ports:
+    - port: 80
+      targetPort: 8000
+  # ClusterIP keeps it internal. Switch to LoadBalancer or add an
+  # Ingress below if you want it reachable outside the cluster.
+  type: ClusterIP


### PR DESCRIPTION
## Summary

Everything needed to build and run Kickflip as a container on k3s.

## What's included

**`Dockerfile`**
- Python 3.11-slim base, non-root user (`app:app`)
- `/data` mount point for the SQLite database — must be a PersistentVolume in k8s
- Built-in `HEALTHCHECK` against `/health`

**`app/main.py`**
- New `GET /health` endpoint returning `{"status": "ok"}` used by readiness/liveness probes

**`docker-compose.yml`**
- For local container testing — `docker compose up --build`
- Named volume for `/data`, `DATABASE_URL` overridden to `/data/grants.db`

**`k8s/`** — apply in order or all at once with `kubectl apply -f k8s/`
| File | Purpose |
|---|---|
| `namespace.yaml` | `kickflip` namespace |
| `secret.yaml` | Template for DD/SN credentials — fill before applying, don't commit real values |
| `configmap.yaml` | Non-sensitive config (pipeline IDs, durations, etc.) |
| `pvc.yaml` | 1Gi `ReadWriteOnce` — works with k3s local-path provisioner out of the box |
| `deployment.yaml` | `replicas: 1` + `Recreate` strategy (SQLite can't handle concurrent writers) |
| `service.yaml` | `ClusterIP` on port 80 |
| `ingress.yaml` | Optional Traefik ingress for external access — update hostname |

## Deployment steps

```bash
# 1. Build and push image
docker build -t your-registry/kickflip:latest .
docker push your-registry/kickflip:latest

# 2. Update image reference in k8s/deployment.yaml

# 3. Fill in k8s/secret.yaml with base64-encoded credentials

# 4. Fill in k8s/configmap.yaml with your pipeline IDs, index name, SN instance

# 5. Apply
kubectl apply -f k8s/
```

## Notes

- `replicas: 1` and `strategy: Recreate` are intentional — SQLite doesn't support concurrent writers. If HA is needed later, migrate `DATABASE_URL` to Postgres first.
- k3s's built-in Traefik handles the Ingress — no extra ingress controller needed.
- The `secret.yaml` is a template only. Use Sealed Secrets or an external secrets manager for production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)