### PR TITLE
Add test suite covering grants, clients, and revert tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ Both Datadog and ServiceNow integrations run in **stub mode** when their env var
 
 ---
 
+## Tests
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+The suite runs against an in-memory SQLite database and mocks the Datadog,
+ServiceNow and scheduler integrations, so no credentials or network access are
+required. Coverage includes the pipeline/index filter builders, the ServiceNow
+validator, the grants REST API, and the background revert/recovery tasks —
+including the case where several of many active grants are revoked individually
+and only those CAR IDs leave the filter.
+
+---
+
 ## Environment variables
 
 | Variable | Required | Description |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests
+filterwarnings =
+    ignore::DeprecationWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+
+pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,125 @@
+"""
+Shared pytest fixtures.
+
+Every test runs against a private in-memory SQLite database (shared across
+connections via StaticPool) so tests never touch the real ``grants.db`` and
+never hit the network. The Datadog, ServiceNow and scheduler integrations are
+replaced with mocks so we can assert exactly what would have been pushed.
+"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app import models  # noqa: F401 — register the ORM model with Base.metadata
+from app.database import Base, get_db
+from app.models import Grant
+
+
+@pytest_asyncio.fixture
+async def engine():
+    """A fresh in-memory database per test, with the schema created."""
+    eng = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest.fixture
+def session_factory(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def session(session_factory):
+    async with session_factory() as s:
+        yield s
+
+
+@pytest.fixture
+def mocks(monkeypatch):
+    """Replace the router's external integrations with mocks."""
+    apply = AsyncMock()
+    apply_index = AsyncMock()
+    validate = AsyncMock(return_value={"number": "INC0001", "state": "2", "priority": "2"})
+    schedule = MagicMock()
+    cancel = MagicMock()
+
+    monkeypatch.setattr("app.routers.grants.apply_active_grants", apply)
+    monkeypatch.setattr("app.routers.grants.apply_active_grants_to_index", apply_index)
+    monkeypatch.setattr("app.routers.grants.validate_incident", validate)
+    monkeypatch.setattr("app.routers.grants.schedule_revert", schedule)
+    monkeypatch.setattr("app.routers.grants.cancel_revert", cancel)
+
+    return SimpleNamespace(
+        apply=apply,
+        apply_index=apply_index,
+        validate=validate,
+        schedule=schedule,
+        cancel=cancel,
+    )
+
+
+@pytest_asyncio.fixture
+async def client(session_factory, mocks):
+    """An httpx client wired to a minimal app exposing the grants router.
+
+    We build a bare FastAPI app (no lifespan) so the real scheduler / DB
+    startup never runs; ``get_db`` is overridden to use the in-memory engine.
+    """
+    from app.routers.grants import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    async def override_get_db():
+        async with session_factory() as s:
+            yield s
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def last_call_car_ids(apply_mock) -> list[str]:
+    """The car_id list passed to the most recent apply_active_grants call."""
+    return list(apply_mock.call_args.args[0])
+
+
+async def make_grant(
+    session_factory,
+    car_id: str,
+    *,
+    status: str = "active",
+    inc_number: str = "INC0001",
+    expires_in: int = 600,
+) -> Grant:
+    """Insert a Grant row directly and return it."""
+    now = datetime.utcnow()
+    grant = Grant(
+        car_id=car_id,
+        inc_number=inc_number,
+        requested_by="tester",
+        created_at=now,
+        expires_at=now + timedelta(seconds=expires_in),
+        status=status,
+    )
+    async with session_factory() as s:
+        s.add(grant)
+        await s.commit()
+        await s.refresh(grant)
+    return grant

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -1,0 +1,109 @@
+"""Tests for the Observability Pipelines client (app/clients/datadog.py)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.clients import datadog
+from app.clients.datadog import (
+    BASE_DEBUG_FILTER,
+    _build_filter,
+    _update_processor_filter,
+    apply_active_grants,
+)
+from app.config import settings
+
+
+# --- _build_filter ---------------------------------------------------------
+
+def test_build_filter_empty_is_base():
+    assert _build_filter([]) == BASE_DEBUG_FILTER
+
+
+def test_build_filter_single_car():
+    assert _build_filter(["1234"]) == "level:debug AND NOT (car_id:1234)"
+
+
+def test_build_filter_multiple_cars_joined_with_or():
+    assert _build_filter(["1234", "5678"]) == (
+        "level:debug AND NOT (car_id:1234 OR car_id:5678)"
+    )
+
+
+# --- _update_processor_filter ----------------------------------------------
+
+def _pipeline(processors):
+    return {"data": {"attributes": {"config": {"processors": processors}}}}
+
+
+def test_update_processor_matches_by_configured_id():
+    data = _pipeline([{"id": settings.dd_filter_processor_id, "include": "level:debug"}])
+    found = _update_processor_filter(data, "level:debug AND NOT (car_id:1)")
+    assert found is True
+    proc = data["data"]["attributes"]["config"]["processors"][0]
+    assert proc["include"] == "level:debug AND NOT (car_id:1)"
+
+
+def test_update_processor_matches_by_base_filter_prefix():
+    # processor id doesn't match, but include starts with the base debug filter
+    data = _pipeline([{"id": "some-other-id", "include": "level:debug AND NOT (car_id:9)"}])
+    found = _update_processor_filter(data, "level:debug")
+    assert found is True
+    assert data["data"]["attributes"]["config"]["processors"][0]["include"] == "level:debug"
+
+
+def test_update_processor_not_found():
+    data = _pipeline([{"id": "unrelated", "include": "service:foo"}])
+    assert _update_processor_filter(data, "level:debug") is False
+
+
+def test_update_processor_handles_missing_config():
+    assert _update_processor_filter({}, "level:debug") is False
+
+
+# --- apply_active_grants ----------------------------------------------------
+
+@pytest.fixture
+def two_pipelines(monkeypatch):
+    monkeypatch.setattr(settings, "dd_pipeline_ids", "pid-A,pid-B")
+
+
+async def test_apply_active_grants_patches_each_pipeline(monkeypatch, two_pipelines):
+    def fresh_pipeline(_client, pid):
+        return _pipeline([{"id": settings.dd_filter_processor_id, "include": "level:debug"}])
+
+    get_mock = AsyncMock(side_effect=fresh_pipeline)
+    patch_mock = AsyncMock()
+    monkeypatch.setattr(datadog, "_get_pipeline", get_mock)
+    monkeypatch.setattr(datadog, "_patch_pipeline", patch_mock)
+
+    await apply_active_grants(["1001", "1002"])
+
+    assert patch_mock.await_count == 2
+    expected = "level:debug AND NOT (car_id:1001 OR car_id:1002)"
+    for call in patch_mock.await_args_list:
+        _client, pid, payload = call.args
+        proc = payload["data"]["attributes"]["config"]["processors"][0]
+        assert proc["include"] == expected
+
+
+async def test_apply_active_grants_skips_pipeline_without_processor(monkeypatch, two_pipelines):
+    get_mock = AsyncMock(return_value=_pipeline([{"id": "x", "include": "service:foo"}]))
+    patch_mock = AsyncMock()
+    monkeypatch.setattr(datadog, "_get_pipeline", get_mock)
+    monkeypatch.setattr(datadog, "_patch_pipeline", patch_mock)
+
+    await apply_active_grants(["1001"])
+
+    # No matching processor → nothing patched
+    patch_mock.assert_not_awaited()
+
+
+async def test_apply_active_grants_no_pipelines_configured(monkeypatch):
+    monkeypatch.setattr(settings, "dd_pipeline_ids", "")
+    patch_mock = AsyncMock()
+    monkeypatch.setattr(datadog, "_patch_pipeline", patch_mock)
+
+    await apply_active_grants(["1001"])
+
+    patch_mock.assert_not_awaited()

--- a/tests/test_datadog_index.py
+++ b/tests/test_datadog_index.py
@@ -1,0 +1,91 @@
+"""Tests for the Log Index client (app/clients/datadog_index.py)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.clients import datadog_index
+from app.clients.datadog_index import (
+    BASE_DEBUG_QUERY,
+    _build_exclusion_query,
+    _update_exclusion_filter,
+    apply_active_grants_to_index,
+)
+from app.config import settings
+
+
+# --- _build_exclusion_query ------------------------------------------------
+
+def test_build_query_empty_is_base():
+    assert _build_exclusion_query([]) == BASE_DEBUG_QUERY
+
+
+def test_build_query_single():
+    assert _build_exclusion_query(["1234"]) == "status:debug AND NOT (car_id:1234)"
+
+
+def test_build_query_multiple():
+    assert _build_exclusion_query(["1234", "5678"]) == (
+        "status:debug AND NOT (car_id:1234 OR car_id:5678)"
+    )
+
+
+# --- _update_exclusion_filter ----------------------------------------------
+
+def _index(query):
+    return {"exclusion_filters": [{"name": "drop-debug", "filter": {"query": query}}]}
+
+
+def test_update_exclusion_filter_found():
+    data = _index("status:debug")
+    found = _update_exclusion_filter(data, "status:debug AND NOT (car_id:1)")
+    assert found is True
+    assert data["exclusion_filters"][0]["filter"]["query"] == "status:debug AND NOT (car_id:1)"
+
+
+def test_update_exclusion_filter_not_found():
+    data = _index("service:foo")
+    assert _update_exclusion_filter(data, "status:debug") is False
+
+
+def test_update_exclusion_filter_no_filters():
+    assert _update_exclusion_filter({}, "status:debug") is False
+
+
+# --- apply_active_grants_to_index ------------------------------------------
+
+async def test_apply_to_index_puts_updated_query(monkeypatch):
+    monkeypatch.setattr(settings, "dd_index_name", "main")
+    get_mock = AsyncMock(return_value=_index("status:debug"))
+    put_mock = AsyncMock()
+    monkeypatch.setattr(datadog_index, "_get_index", get_mock)
+    monkeypatch.setattr(datadog_index, "_put_index", put_mock)
+
+    await apply_active_grants_to_index(["1001", "1002"])
+
+    put_mock.assert_awaited_once()
+    _client, payload = put_mock.await_args.args
+    query = payload["exclusion_filters"][0]["filter"]["query"]
+    assert query == "status:debug AND NOT (car_id:1001 OR car_id:1002)"
+
+
+async def test_apply_to_index_no_index_configured(monkeypatch):
+    monkeypatch.setattr(settings, "dd_index_name", "")
+    put_mock = AsyncMock()
+    monkeypatch.setattr(datadog_index, "_put_index", put_mock)
+
+    await apply_active_grants_to_index(["1001"])
+
+    put_mock.assert_not_awaited()
+
+
+async def test_apply_to_index_skips_when_filter_missing(monkeypatch):
+    monkeypatch.setattr(settings, "dd_index_name", "main")
+    get_mock = AsyncMock(return_value=_index("service:foo"))
+    put_mock = AsyncMock()
+    monkeypatch.setattr(datadog_index, "_get_index", get_mock)
+    monkeypatch.setattr(datadog_index, "_put_index", put_mock)
+
+    await apply_active_grants_to_index(["1001"])
+
+    put_mock.assert_not_awaited()

--- a/tests/test_grants_api.py
+++ b/tests/test_grants_api.py
@@ -1,0 +1,123 @@
+"""Tests for the grants REST API (app/routers/grants.py)."""
+
+import pytest
+
+from tests.conftest import last_call_car_ids
+
+
+async def _create(client, car_id, inc="INC0001"):
+    resp = await client.post(
+        "/api/grants",
+        json={"car_id": car_id, "inc_number": inc, "requested_by": "tester"},
+    )
+    return resp
+
+
+# --- create ----------------------------------------------------------------
+
+async def test_create_grant_returns_active_grant(client, mocks):
+    resp = await _create(client, "1001")
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["car_id"] == "1001"
+    assert body["status"] == "active"
+    assert body["seconds_remaining"] > 0
+    # filter pushed to both pipeline and index with the new car_id
+    assert last_call_car_ids(mocks.apply) == ["1001"]
+    mocks.apply_index.assert_awaited()
+    mocks.schedule.assert_called_once()
+
+
+async def test_create_grant_validates_incident_prefix(client):
+    resp = await _create(client, "1001", inc="CHG123")
+    assert resp.status_code == 422
+
+
+async def test_create_grant_rejects_empty_car_id(client):
+    resp = await _create(client, "   ")
+    assert resp.status_code == 422
+
+
+async def test_duplicate_active_car_id_conflicts(client, mocks):
+    assert (await _create(client, "1001")).status_code == 201
+    dup = await _create(client, "1001")
+    assert dup.status_code == 409
+    assert "already exists" in dup.json()["detail"]
+
+
+async def test_failed_incident_validation_blocks_grant(client, mocks):
+    from app.clients.servicenow import IncidentValidationError
+
+    mocks.validate.side_effect = IncidentValidationError("Incident INC0001 not found")
+    resp = await _create(client, "1001")
+    assert resp.status_code == 422
+    # nothing pushed when validation fails
+    mocks.apply.assert_not_awaited()
+
+
+# --- list ------------------------------------------------------------------
+
+async def test_list_grants(client):
+    await _create(client, "1001")
+    await _create(client, "1002")
+    resp = await client.get("/api/grants")
+    assert resp.status_code == 200
+    car_ids = {g["car_id"] for g in resp.json()}
+    assert car_ids == {"1001", "1002"}
+
+
+# --- revoke ----------------------------------------------------------------
+
+async def test_revoke_marks_reverted_and_cancels_job(client, mocks):
+    created = (await _create(client, "1001")).json()
+    resp = await client.delete(f"/api/grants/{created['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "reverted"
+    assert resp.json()["reverted_at"] is not None
+    mocks.cancel.assert_called_once_with(created["id"])
+    # after revoking the only grant, the filter is cleared
+    assert last_call_car_ids(mocks.apply) == []
+
+
+async def test_revoke_missing_grant_404(client):
+    resp = await client.delete("/api/grants/999")
+    assert resp.status_code == 404
+
+
+async def test_revoke_already_reverted_409(client, mocks):
+    created = (await _create(client, "1001")).json()
+    await client.delete(f"/api/grants/{created['id']}")
+    again = await client.delete(f"/api/grants/{created['id']}")
+    assert again.status_code == 409
+    assert "already" in again.json()["detail"]
+
+
+# --- the headline scenario: revoke 3 of 5 ----------------------------------
+
+async def test_revoking_three_of_five_leaves_only_the_other_two(client, mocks):
+    """5 active grants, manually revoke 3 → only those 3 car_ids leave the
+    filter; the remaining 2 stay protected."""
+    ids = {}
+    for car in ["1001", "1002", "1003", "1004", "1005"]:
+        ids[car] = (await _create(client, car)).json()["id"]
+
+    # All five are present in the most recent filter push.
+    assert set(last_call_car_ids(mocks.apply)) == {"1001", "1002", "1003", "1004", "1005"}
+
+    # Manually revoke three specific grants.
+    for car in ["1002", "1003", "1004"]:
+        resp = await client.delete(f"/api/grants/{ids[car]}")
+        assert resp.status_code == 200
+
+    # The final filter pushed to Datadog contains exactly the two survivors.
+    assert set(last_call_car_ids(mocks.apply)) == {"1001", "1005"}
+    assert set(last_call_car_ids(mocks.apply_index)) == {"1001", "1005"}
+
+    # Only the three revoked grants' scheduler jobs were cancelled.
+    cancelled = {c.args[0] for c in mocks.cancel.call_args_list}
+    assert cancelled == {ids["1002"], ids["1003"], ids["1004"]}
+
+    # And the API still reports exactly the two as active.
+    listed = (await client.get("/api/grants")).json()
+    active = {g["car_id"] for g in listed if g["status"] == "active"}
+    assert active == {"1001", "1005"}

--- a/tests/test_servicenow.py
+++ b/tests/test_servicenow.py
@@ -1,0 +1,83 @@
+"""Tests for the ServiceNow incident validator (app/clients/servicenow.py)."""
+
+import httpx
+import pytest
+
+from app.clients import servicenow
+from app.clients.servicenow import IncidentValidationError, validate_incident
+from app.config import settings
+
+
+@pytest.fixture
+def sn_configured(monkeypatch):
+    monkeypatch.setattr(settings, "sn_instance", "acme.service-now.com")
+    monkeypatch.setattr(settings, "sn_user", "svc")
+    monkeypatch.setattr(settings, "sn_pass", "secret")
+    monkeypatch.setattr(settings, "sn_min_severity", 2)
+
+
+_RealAsyncClient = httpx.AsyncClient
+
+
+def _install_response(monkeypatch, *, json=None, status_code=200):
+    """Route servicenow's httpx calls through a MockTransport."""
+
+    def handler(request):
+        return httpx.Response(status_code, json=json if json is not None else {})
+
+    def factory(*args, **kwargs):
+        return _RealAsyncClient(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(servicenow.httpx, "AsyncClient", factory)
+
+
+# --- stub mode (unconfigured) ----------------------------------------------
+
+async def test_stub_mode_accepts_anything(monkeypatch):
+    monkeypatch.setattr(settings, "sn_instance", "")
+    inc = await validate_incident("INC9999")
+    assert inc["number"] == "INC9999"
+    assert "stub" in inc["short_description"].lower()
+
+
+# --- configured: happy path ------------------------------------------------
+
+async def test_valid_active_high_priority_incident(monkeypatch, sn_configured):
+    _install_response(
+        monkeypatch,
+        json={"result": [{"number": "INC0001", "state": "2", "priority": "1"}]},
+    )
+    inc = await validate_incident("INC0001")
+    assert inc["number"] == "INC0001"
+
+
+# --- configured: failure paths ---------------------------------------------
+
+async def test_incident_not_found(monkeypatch, sn_configured):
+    _install_response(monkeypatch, json={"result": []})
+    with pytest.raises(IncidentValidationError, match="not found"):
+        await validate_incident("INC0002")
+
+
+async def test_inactive_incident_rejected(monkeypatch, sn_configured):
+    _install_response(
+        monkeypatch,
+        json={"result": [{"number": "INC0003", "state": "6", "priority": "1"}]},
+    )
+    with pytest.raises(IncidentValidationError, match="not active"):
+        await validate_incident("INC0003")
+
+
+async def test_low_priority_rejected(monkeypatch, sn_configured):
+    _install_response(
+        monkeypatch,
+        json={"result": [{"number": "INC0004", "state": "2", "priority": "3"}]},
+    )
+    with pytest.raises(IncidentValidationError, match="minimum"):
+        await validate_incident("INC0004")
+
+
+async def test_http_error_surfaces_validation_error(monkeypatch, sn_configured):
+    _install_response(monkeypatch, status_code=401, json={})
+    with pytest.raises(IncidentValidationError, match="HTTP 401"):
+        await validate_incident("INC0005")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,75 @@
+"""Tests for background tasks (app/tasks.py)."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from app import tasks
+from app.models import Grant
+from tests.conftest import last_call_car_ids, make_grant
+
+
+@pytest.fixture
+def task_env(monkeypatch, session_factory):
+    """Point tasks at the test DB and stub out the Datadog pushes."""
+    apply = AsyncMock()
+    apply_index = AsyncMock()
+    monkeypatch.setattr(tasks, "AsyncSessionLocal", session_factory)
+    monkeypatch.setattr(tasks, "apply_active_grants", apply)
+    monkeypatch.setattr(tasks, "apply_active_grants_to_index", apply_index)
+    return apply, apply_index
+
+
+async def _status(session_factory, grant_id):
+    async with session_factory() as s:
+        g = await s.get(Grant, grant_id)
+        return g.status
+
+
+# --- revert_grant ----------------------------------------------------------
+
+async def test_revert_grant_reverts_only_target(task_env, session_factory):
+    apply, apply_index = task_env
+    g1 = await make_grant(session_factory, "1001")
+    g2 = await make_grant(session_factory, "1002")
+
+    await tasks.revert_grant(g1.id, g1.car_id)
+
+    assert await _status(session_factory, g1.id) == "reverted"
+    assert await _status(session_factory, g2.id) == "active"
+    # remaining active set pushed = just the survivor
+    assert last_call_car_ids(apply) == ["1002"]
+    assert last_call_car_ids(apply_index) == ["1002"]
+
+
+async def test_revert_grant_missing_is_noop(task_env, session_factory):
+    apply, _ = task_env
+    await tasks.revert_grant(999, "9999")
+    apply.assert_not_awaited()
+
+
+async def test_revert_grant_already_reverted_is_noop(task_env, session_factory):
+    apply, _ = task_env
+    g = await make_grant(session_factory, "1001", status="reverted")
+    await tasks.revert_grant(g.id, g.car_id)
+    apply.assert_not_awaited()
+
+
+# --- recover_on_startup ----------------------------------------------------
+
+async def test_recover_expires_only_past_due_grants(task_env, session_factory):
+    apply, apply_index = task_env
+    # already past its window — should be expired
+    stale = await make_grant(session_factory, "1001", expires_in=-60)
+    # still within window — should remain active
+    fresh = await make_grant(session_factory, "1002", expires_in=600)
+
+    await tasks.recover_on_startup()
+
+    assert await _status(session_factory, stale.id) == "expired"
+    assert await _status(session_factory, fresh.id) == "active"
+    # the pushed filter reflects only the still-active grant
+    assert last_call_car_ids(apply) == ["1002"]
+    assert last_call_car_ids(apply_index) == ["1002"]


### PR DESCRIPTION
Wire up pytest with an in-memory SQLite database and mocked Datadog, ServiceNow and scheduler integrations (no credentials/network needed).

Coverage:
- datadog/datadog_index filter builders and apply_active_grants(_to_index)
- ServiceNow validator: stub mode + active/severity/error paths
- grants REST API: create/list/revoke, validation, duplicate conflicts
- the headline scenario: revoke 3 of 5 active grants and assert only those 3 CAR IDs leave the filter while the other 2 stay protected
- background revert_grant() and recover_on_startup() tasks

https://claude.ai/code/session_01HYenjpLP1bSigCQYB9g7Xh