### PR TITLE
Pin greenlet explicitly as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.115.5
 uvicorn[standard]==0.32.1
 sqlalchemy==2.0.36
+greenlet==3.5.1
 aiosqlite==0.20.0
 apscheduler==3.10.4
 httpx==0.27.2


### PR DESCRIPTION
## Summary

Adds `greenlet==3.5.1` as an explicit dependency in `requirements.txt`.

SQLAlchemy's async engine requires `greenlet`, but SQLAlchemy only auto-installs it on platform/Python combinations that ship a prebuilt wheel. On platforms where it's skipped (e.g. some Windows + Python combos), this surfaces as:

```
ValueError: the greenlet library is required to use this function. No module named 'greenlet'
```

This affects not just the async DB tests but the **app at runtime** too, since the server uses async SQLAlchemy. Pinning it directly guarantees it's always installed.

## Testing

- `python -m pytest` → 39 passed
- Verified the failure mode and fix on a Windows checkout (manual `pip install greenlet` resolved the 14 erroring DB tests; this PR makes that permanent).

https://claude.ai/code/session_01HYenjpLP1bSigCQYB9g7Xh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYenjpLP1bSigCQYB9g7Xh)_